### PR TITLE
Pull translations above 75%

### DIFF
--- a/jenkins/translation_sync/job.sh
+++ b/jenkins/translation_sync/job.sh
@@ -51,7 +51,7 @@ fi
 cd l10n/ 
 perl l10n.pl $APPNAME read 
 tx -d push -s 
-tx -d pull -a 
+tx -d pull -a --minimum-perc=75
 perl l10n.pl $APPNAME write 
 find . -name \*.po -type f -delete
 find . -name \*.pot -type f -delete


### PR DESCRIPTION
tx client offers us the minimum percentage to download. By using this we will be reducing the size of the packet and also push the language teams to complete the translations at least this much to include in next ownCloud version. Otherwise, we have too many languages with 0 percentage.

Opinions?
