### PR TITLE
Add the _ to plural string keys again

### DIFF
--- a/jenkins/translation_sync/l10n.pl
+++ b/jenkins/translation_sync/l10n.pl
@@ -135,11 +135,11 @@ elsif( $task eq 'write' ){
 				elsif( defined( $string->msgstr_n() )){
 					# plural translations
 					my @variants = ();
-                                        my $msgid = $string->msgid();
-                                        $msgid =~ s/^"(.*)"$/$1/;
-                                        my $msgid_plural = $string->msgid_plural();
-                                        $msgid_plural =~ s/^"(.*)"$/$1/;
-					my $identifier = $msgid."::".$msgid_plural;
+					my $msgid = $string->msgid();
+					$msgid =~ s/^"(.*)"$/$1/;
+					my $msgid_plural = $string->msgid_plural();
+					$msgid_plural =~ s/^"(.*)"$/$1/;
+					my $identifier = "_" . $msgid."_::_".$msgid_plural . "_";
 
 					foreach my $variant ( sort { $a <=> $b} keys( %{$string->msgstr_n()} )){
 						push( @variants, $string->msgstr_n()->{$variant} );


### PR DESCRIPTION
With https://github.com/owncloud/administration/commit/c67eaa11c04d0989ee9331c97788a0225a82e7f5 we fixed `"` in translations. However this also removed the leading and trailing `_` in the key of the translations: https://github.com/owncloud/activity/commit/0a32041eacc98c82875b983278796fa474ec72d6

The underscore is however required by the php and js implementation:
https://github.com/owncloud/core/blob/cbad5c998b260040523ac8e6a2797591d0086938/lib/private/l10n.php#L239-239
https://github.com/owncloud/core/blob/bfdf0db7c069f3a456c48b185f6222c1dcef2bbe/core/js/l10n.js#L188-188

by hardcoding them back into the key, plurals work again in apps.

I suggest to port both fixes to the implementation in core aswell, so when we start using them someday, they work as intended. (They will show up fine in transifex, but will just not be found in owncloud itself later)