### PR TITLE
Ignore empty plurals just like with singulars

### DIFF
--- a/jenkins/translation_sync/l10n.pl
+++ b/jenkins/translation_sync/l10n.pl
@@ -127,7 +127,7 @@ elsif( $task eq 'write' ){
 			my @js_strings = ();
 			my $plurals;
 
-			foreach my $string ( @{$array} ){
+			TRANSLATIONS: foreach my $string ( @{$array} ){
 				if( $string->msgid() eq '""' ){
 					# Translator information
 					$plurals = getPluralInfo( $string->msgstr());
@@ -142,6 +142,7 @@ elsif( $task eq 'write' ){
 					my $identifier = "_" . $msgid."_::_".$msgid_plural . "_";
 
 					foreach my $variant ( sort { $a <=> $b} keys( %{$string->msgstr_n()} )){
+						next TRANSLATIONS if $string->msgstr_n()->{$variant} eq '""';
 						push( @variants, $string->msgstr_n()->{$variant} );
 					}
 
@@ -150,7 +151,7 @@ elsif( $task eq 'write' ){
 				}
 				else{
 					# singular translations
-					next if $string->msgstr() eq '""';
+					next TRANSLATIONS if $string->msgstr() eq '""';
 					push( @strings, $string->msgid()." => ".$string->msgstr());
 					push( @js_strings, $string->msgid()." : ".$string->msgstr());
 				}


### PR DESCRIPTION
The js and php code of n() has fallbacks for when the key is missing.
However there is no fallback, when the key is defined with an array of empty
strings. So we just don't extract them anymore and use the english language.

Can be tested with activity app and the ar.json file.
This should resolve the problem with the missing fallback for plurals in JS, that @MorrisJobke mentioned in https://github.com/owncloud/core/pull/14297

@DeepDiver1975 

I will send a PR to core, to remove those broken plurals in stable* branches.
Master will be updated in the next night with the transifex update.