### PR TITLE
Remove translations that have not been extracted with the min 75%

### DIFF
--- a/jenkins/translation_sync/job.sh
+++ b/jenkins/translation_sync/job.sh
@@ -52,7 +52,10 @@ cd l10n/
 perl l10n.pl $APPNAME read 
 tx -d push -s 
 tx -d pull -a --minimum-perc=75
+# update translations that have 75% or more translated
 perl l10n.pl $APPNAME write 
+# remove the remaining translatinos
+perl l10n.pl $APPNAME clean
 find . -name \*.po -type f -delete
 find . -name \*.pot -type f -delete
 cd ..

--- a/jenkins/translation_sync/l10n.pl
+++ b/jenkins/translation_sync/l10n.pl
@@ -192,6 +192,25 @@ elsif( $task eq 'write' ){
 		chdir( $whereami );
 	}
 }
+elsif( $task eq 'clean' ){
+	print "Mode: clean\n";
+	foreach my $file ( @files ){
+		next if -d $file;
+		next if $file eq ".gitkeep";
+		next if $file eq "no-php";
+
+		if ((substr $file, -5) eq ".json" && ! -e "$whereami/" . (substr $file, 0, -5) . "/$app.po") {
+			print "Language " . (substr $file, 0, -5) . " not above 75\%, deleting $file\n";
+			unlink "$file";
+		} elsif ((substr $file, -3) eq ".js" && ! -e "$whereami/" . (substr $file, 0, -3) . "/$app.po") {
+			print "Language " . (substr $file, 0, -3) . " not above 75\%, deleting $file\n";
+			unlink "$file";
+		} elsif ((substr $file, -4) eq ".php" && ! -e "$whereami/" . (substr $file, 0, -4) . "/$app.po") {
+			print "Language " . (substr $file, 0, -4) . " not above 75\%, deleting $file\n";
+			unlink "$file";
+		}
+	}
+}
 else{
 	print "unknown task!\n";
 }


### PR DESCRIPTION
@DeepDiver1975 as discussed 2 weeks ago

We shouldn't ship, what we don't update.

Either the file has been extracted with the min. 75% translation quota, then we update the files,
or it has not been extracted, which means the translation is quite outdated and we should remove it.

PS: did not test this
