### PR TITLE
Makes sure OC 8.1 packages requires PHP < 7. closes #25117

### DIFF
--- a/jenkins/obs_integration/templates/owncloud/8.1/owncloud.spec
+++ b/jenkins/obs_integration/templates/owncloud/8.1/owncloud.spec
@@ -212,6 +212,7 @@ Summary:      Common code server for ownCloud
 %if 0%{?fedora_version} || 0%{?rhel} || 0%{?rhel_version} || 0%{?centos_version}
 Requires:       sqlite
 Requires:       %{ocphp} >= 5.4.0
+Requires:       %{ocphp} < 7.0.0
 Requires:       %{ocphp}-json %{ocphp}-mbstring %{ocphp}-process %{ocphp}-xml %{ocphp}-zip
 # core#13357, core#13944
 Requires:	%{ocphp}-posix %{ocphp}-gd
@@ -384,6 +385,7 @@ popd
 
 echo "repository: |%{_repository}|"
 echo "Requires:       %{ocphp} >= 5.4.0"
+ echo "Requires:      %{ocphp} < 7.0.0"
 
 # remove .bower.json .bowerrc .gitattributes .gitmodules
 find . -name .bower\* -print -o -name .git\* -print | xargs rm


### PR DESCRIPTION
this makes sure oc 8.1 do not get php7 installed which is incompatible.