### PR TITLE
Make PHP_OS uppercase before checking for Windows

### DIFF
--- a/web-installer/setup-owncloud.php
+++ b/web-installer/setup-owncloud.php
@@ -77,8 +77,8 @@ class Setup {
 			$error.='PHP 5.6.0 is required. Please ask your server administrator to update PHP to version 5.6.0 or higher.<br/>';
 		}
 
-		// running oC on windows is unsupported since 8.1
-		if(substr(PHP_OS, 0, 3) === "WIN") {
+		// running oC on Windows is unsupported since 8.1
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 			$error.='ownCloud Server does not support Microsoft Windows.<br/>';
 		}
 


### PR DESCRIPTION
As discussed in https://github.com/owncloud/core/pull/26316

> According to:
>
>https://gist.github.com/asika32764/90e49a82c124858c9e1a
>
>http://stackoverflow.com/questions/738823/possible-values-for-php-os
>
>there are three possible values on Windows:
>
>WIN32
>WINNT
>Windows