### PR TITLE
Add caja plugin to OBS builds.

### DIFF
--- a/jenkins/obs_integration/templates/client/v2_3_0/SHORTNAME-client.spec.in
+++ b/jenkins/obs_integration/templates/client/v2_3_0/SHORTNAME-client.spec.in
@@ -270,6 +270,7 @@ Requires:       %{qtprefix}qt5-qtwebkit
 # Fedora-19 and -20, CentOS-6, CentOS-7, RHEL_6,7 don't have Suggests.
 Suggests:	%{name}-nautilus
 Suggests:       %{name}-nemo
+Suggests:       %{name}-caja
 %endif
 
 %if 0%{?rhel_version} == 600 || 0%{?centos_version} == 600
@@ -378,6 +379,22 @@ Obsoletes:      opt-%{name}-nemo
 %description -n %{name}-nemo
 This package provides overlay icons to visualize the synchronization state
 in the Nemo file manager.
+
+%package -n %{name}-caja
+Summary:        Caja overlay icons
+Group:          Productivity/Networking/Other
+Requires:       caja
+%if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
+Requires:       caja-python
+%else
+Requires:       python-caja
+%endif
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Obsoletes:      opt-%{name}-caja
+
+%description -n %{name}-caja
+This package provides overlay icons to visualize the synchronization state
+in the Caja file manager.
 
 %if 0%{build_dolphin_overlays}
 %package -n %{name}-dolphin
@@ -604,6 +621,13 @@ fi
 %{_datadir}/nemo-python/extensions/syncstate-*.py*
 %dir %{_datadir}/nemo-python
 %dir %{_datadir}/nemo-python/extensions/
+
+%files -n %{name}-caja
+%defattr(-,root,root,-)
+# Fedora also has *.pyc and *.pyo files here.
+%{_datadir}/caja-python/extensions/syncstate-*.py*
+%dir %{_datadir}/caja-python
+%dir %{_datadir}/caja-python/extensions/
 
 %if 0%{build_dolphin_overlays}
 %files -n %{name}-dolphin

--- a/jenkins/obs_integration/templates/client/v2_3_0/debian.SHORTNAME-client-caja.install.in
+++ b/jenkins/obs_integration/templates/client/v2_3_0/debian.SHORTNAME-client-caja.install.in
@@ -1,0 +1,1 @@
+usr/share/caja-python/extensions/syncstate-*.py*

--- a/jenkins/obs_integration/templates/client/v2_3_0/debian.control.in
+++ b/jenkins/obs_integration/templates/client/v2_3_0/debian.control.in
@@ -74,3 +74,12 @@ Description: Nemo plugin for [% displayname %]
  This package contains a nemo plugin to display overlay icons.
  .
  This is a nice gui feature.
+
+Package: [% shortname %]-client-caja
+Architecture: all
+Section: devel
+Depends: [% shortname %]-client (= ${binary:Version}), ${misc:Depends}, lib[% shortname %]sync0, python-caja, caja
+Description: Caja plugin for [% displayname %]
+ This package contains a caja plugin to display overlay icons.
+ .
+ This is a nice gui feature.


### PR DESCRIPTION
Add the caja plugin added in owncloud/client#5262 to the obs packages.
This is a direct copy and replace of the nemo packaging options.

I'm still a bit confused what the different folders v2.2.4/v2.3/v2.4 are used for. I added it to the 2.3 version as suggested [here](/owncloud/client/pull/5262). Is this enough to get it to build with the 2.3 version? Should I also submit it to the v2.4 directory?

Anything else I missed? (I can't really test it obviously.)
