### PR TITLE
Updater 8.2.10 to 9.0.8

### DIFF
--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -224,8 +224,8 @@ return [
 			'latest' => '8.2.10',
 			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
 		],
-		'8.2.9' => [
-			'latest' => '9.0.6',
+		'8.2.10' => [
+			'latest' => '9.0.8',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 		],
 		'8.1' => [

--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -163,6 +163,10 @@ return [
 			'latest' => '8.2.10',
 			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
 		],
+		'8.2.10' => [
+			'latest' => '9.0.8',
+			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
+		],
 		'8.1' => [
 			'latest' => '8.1.12',
 			'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',

--- a/update-server/tests/integration/features/update.beta.feature
+++ b/update-server/tests/integration/features/update.beta.feature
@@ -56,13 +56,13 @@ Feature: Testing the update scenario of releases on the beta channel
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 8.2.x should go below #####
-  Scenario: Updating an outdated ownCloud 8.2.9 on the beta channel
+  Scenario: Updating an outdated ownCloud 8.2.10 on the beta channel
     Given There is a release with channel "beta"
-    And The received version is "8.2.9"
+    And The received version is "8.2.10"
     When The request is sent
     Then The response is non-empty
-    And Update to version "9.0.6" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.6.zip"
+    And Update to version "9.0.8" is available
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.8.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 8.2.0 on the beta channel

--- a/update-server/tests/integration/features/update.stable.feature
+++ b/update-server/tests/integration/features/update.stable.feature
@@ -70,7 +70,9 @@ Feature: Testing the update scenario of releases on the stable channel
     Given There is a release with channel "stable"
     And The received version is "8.2.10"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.8.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 8.2.0 on the stable channel
     Given There is a release with channel "stable"


### PR DESCRIPTION
Unlock 8.2.10 to 9.0.8 on beta and stable channels.

Production channel stays 8.2.10 for 8.2.x and 9.0.8 for 9.0.x

