### PR TITLE
WIP - allows upgrade testing ....

### DIFF
--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -15,7 +15,7 @@ if [ "$#" -ne 3 ]; then
     echo "Usage: test-upgrade <from-version> <to-version> <database>"
     echo "Example: test-upgrade 5.0.13 6.0.0 pgsql"
     echo "Valid databases: sqlite mysql pgsql"
-    exit
+    exit 1
 fi
 
 FROM_VERSION=$1
@@ -64,12 +64,12 @@ fi
 
 if [ ! -f $FROM ]; then
   echo "Could not download $FROM"
-  exit
+  exit 1
 fi
 
 if [ ! -f $TO ]; then
   echo "Could not download $TO"
-  exit
+  exit 1
 fi
 
 

--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -224,7 +224,11 @@ echo "Start upgrading from $FROM to $TO"
 ./occ upgrade
 
 if [ -d tests ]; then
+  # for now disable gallery
+  ./occ app:disable gallery
+  # run the tests
   cd tests
+  chmod +x ../lib/composer/bin/phpunit
   ../lib/composer/bin/phpunit --configuration phpunit-autotest.xml --log-junit "autotest-results-$DATABASE.xml"
 
 #  make clean-test-integration

--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -12,6 +12,9 @@ ADMINLOGIN=admin$EXECUTOR_NUMBER
 DATABASEHOST=localhost
 BASEDIR=$PWD
 
+PHP_OLD=php5.6
+PHP_NEW=php7.2
+
 if [ "$#" -ne 3 ]; then
     echo "Usage: test-upgrade <from-version> <to-version> <database>"
     echo "Example: test-upgrade 5.0.13 6.0.0 pgsql"
@@ -174,7 +177,7 @@ cd owncloud
 mkdir data
 
 # installation
-./occ maintenance:install -vvv --database="$_DB" --database-name="$DATABASENAME" --database-host="$DATABASEHOST" --database-user="$DATABASEUSER" --database-pass=owncloud --database-table-prefix=oc_ --admin-user="$ADMINLOGIN" --admin-pass=admin
+$PHP_OLD ./occ maintenance:install -vvv --database="$_DB" --database-name="$DATABASENAME" --database-host="$DATABASEHOST" --database-user="$DATABASEUSER" --database-pass=owncloud --database-table-prefix=oc_ --admin-user="$ADMINLOGIN" --admin-pass=admin
 
 #if [ -f console.php ]; then
 #  # install test data
@@ -192,25 +195,25 @@ mkdir data
 # fire up the cron scheduler
 echo "Running the cron scheduler ..."
 cd $DATADIR/owncloud
-php -f cron.php
-php -f cron.php
+$PHP_OLD -f cron.php
+$PHP_OLD -f cron.php
 echo "Done."
 
 echo $GIT_BRANCH
 # remove apps after upgrade
-./occ app:disable activity
-./occ app:disable files_pdfviewer
-./occ app:disable files_texteditor
-./occ app:disable gallery
-./occ app:disable files_videoplayer
-./occ app:disable files_videoviewer
-./occ app:disable updater
+$PHP_OLD ./occ app:disable activity
+$PHP_OLD ./occ app:disable files_pdfviewer
+$PHP_OLD ./occ app:disable files_texteditor
+$PHP_OLD ./occ app:disable gallery
+$PHP_OLD ./occ app:disable files_videoplayer
+$PHP_OLD ./occ app:disable files_videoviewer
+$PHP_OLD ./occ app:disable updater
 
 if [ -v GIT_BRANCH ]; then
-	./occ app:disable configreport
-	./occ app:disable firstrunwizard
-	./occ app:disable notifications
-	./occ app:disable templateeditor
+	$PHP_OLD ./occ app:disable configreport
+	$PHP_OLD ./occ app:disable firstrunwizard
+	$PHP_OLD ./occ app:disable notifications
+	$PHP_OLD ./occ app:disable templateeditor
 fi
 
 # cleanup old code
@@ -234,16 +237,16 @@ if [ ! -d apps/market ]; then
   cd ../..
 fi
 
-./occ upgrade || true
+$PHP_NEW ./occ upgrade || true
 #./occ main:mode --off || true
 
 if [ -d tests ]; then
-  ./occ app:disable gallery
+  $PHP_NEW ./occ app:disable gallery
 
   # run the phpunit tests
   cd tests
   chmod +x ../lib/composer/phpunit/phpunit/phpunit
-  ../lib/composer/phpunit/phpunit/phpunit --configuration phpunit-autotest.xml --log-junit "autotest-results-$DATABASE.xml"
+  $PHP_NEW ../lib/composer/phpunit/phpunit/phpunit --configuration phpunit-autotest.xml --log-junit "autotest-results-$DATABASE.xml"
 
 #  make clean-test-integration
 #  make test-integration OC_TEST_ALT_HOME=1

--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -31,22 +31,20 @@ TO=owncloud-$TO_VERSION.tar.bz2
 if [[ $TO_VERSION == git* ]]; then
   GIT_BRANCH=`echo $TO_VERSION | cut -c 5-`
   TO=$GIT_BRANCH.tar.bz2
-  if [ ! -f $TO ]; then
-    rm -f $TO
-    rm -rf g
-    mkdir g
-    cd g
-    git clone -b $GIT_BRANCH --recursive --depth 1 https://github.com/owncloud/core.git owncloud
-    if [ -f owncloud/Makefile ]; then
-      cd owncloud
-      make
-      cd ..
-    fi
-    tar -cjf $TO owncloud
-    mv $TO ..
-    cd ..
-    rm -rf g
-  fi
+	rm -f $TO
+	rm -rf g
+	mkdir g
+	cd g
+	git clone -b $GIT_BRANCH --recursive --depth 1 https://github.com/owncloud/core.git owncloud
+	if [ -f owncloud/Makefile ]; then
+	  cd owncloud
+	  make
+	  cd ..
+	fi
+	tar -cjf $TO owncloud
+	mv $TO ..
+	cd ..
+	rm -rf g
 fi
 
 DATADIR=$BASEDIR/$FROM_VERSION-$TO_VERSION-$DATABASE

--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -240,10 +240,10 @@ fi
 if [ -d tests ]; then
   ./occ app:disable gallery
 
-  # run the tests
+  # run the phpunit tests
   cd tests
-  chmod +x ../lib/composer/bin/phpunit
-  ../lib/composer/bin/phpunit --configuration phpunit-autotest.xml --log-junit "autotest-results-$DATABASE.xml"
+  chmod +x ../lib/composer/phpunit/phpunit/phpunit
+  ../lib/composer/phpunit/phpunit/phpunit --configuration phpunit-autotest.xml --log-junit "autotest-results-$DATABASE.xml"
 
 #  make clean-test-integration
 #  make test-integration OC_TEST_ALT_HOME=1

--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -12,8 +12,8 @@ ADMINLOGIN=admin$EXECUTOR_NUMBER
 DATABASEHOST=localhost
 BASEDIR=$PWD
 
-PHP_OLD=php5.6
-PHP_NEW=php7.2
+PHP_OLD=php7.0
+PHP_NEW=php7.1
 
 if [ "$#" -ne 3 ]; then
     echo "Usage: test-upgrade <from-version> <to-version> <database>"
@@ -23,6 +23,7 @@ if [ "$#" -ne 3 ]; then
 fi
 
 set -e
+export ZEND_DONT_UNLOAD_MODULES=1
 
 FROM_VERSION=$1
 TO_VERSION=$2

--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -18,6 +18,8 @@ if [ "$#" -ne 3 ]; then
     exit 1
 fi
 
+set -e
+
 FROM_VERSION=$1
 TO_VERSION=$2
 DATABASE=$3

--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -55,15 +55,15 @@ fi
 DATADIR=$BASEDIR/$FROM_VERSION-$TO_VERSION-$DATABASE
 
 if [ ! -f $FROM ]; then
-  wget http://download.owncloud.org/community/$FROM || true
-  wget http://download.owncloud.org/community/testing/$FROM || true
+  wget -nv http://download.owncloud.org/community/$FROM || true
+  wget -nv http://download.owncloud.org/community/testing/$FROM || true
 else
   echo "Reuse existing $FROM"
 fi
 
 if [ ! -f $TO ]; then
-  wget http://download.owncloud.org/community/$TO || true
-  wget http://download.owncloud.org/community/testing/$TO || true
+  wget -nv http://download.owncloud.org/community/$TO || true
+  wget -nv http://download.owncloud.org/community/testing/$TO || true
 else
   echo "Reuse existing $TO"
 fi
@@ -237,8 +237,9 @@ if [ ! -d apps/market ]; then
   cd ../..
 fi
 
-$PHP_NEW ./occ upgrade || true
+$PHP_NEW ./occ upgrade
 #./occ main:mode --off || true
+$PHP_NEW ./occ a:l || true
 
 if [ -d tests ]; then
   $PHP_NEW ./occ app:disable gallery

--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -229,6 +229,7 @@ if [ ! -d apps/market ]; then
   git clone git@github.com:owncloud/market.git
   cd market
   make
+  cd ../..
 fi
 
 ./occ upgrade || true

--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -206,7 +206,6 @@ echo $GIT_BRANCH
 
 if [ -v GIT_BRANCH ]; then
 	./occ app:disable configreport
-	./occ app:disable files_pdfviewer
 	./occ app:disable firstrunwizard
 	./occ app:disable notifications
 	./occ app:disable templateeditor
@@ -225,7 +224,15 @@ cd owncloud
 
 # UPGRADE
 echo "Start upgrading from $FROM to $TO"
-./occ upgrade
+if [ ! -d apps/market ]; then
+  cd apps
+  git clone git@github.com:owncloud/market.git
+  cd market
+  make
+fi
+
+./occ upgrade || true
+#./occ main:mode --off || true
 
 if [ -d tests ]; then
   ./occ app:disable gallery

--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -51,15 +51,15 @@ fi
 DATADIR=$BASEDIR/$FROM_VERSION-$TO_VERSION-$DATABASE
 
 if [ ! -f $FROM ]; then
-  wget http://download.owncloud.org/community/$FROM
-  wget http://download.owncloud.org/community/testing/$FROM
+  wget http://download.owncloud.org/community/$FROM || true
+  wget http://download.owncloud.org/community/testing/$FROM || true
 else
   echo "Reuse existing $FROM"
 fi
 
 if [ ! -f $TO ]; then
-  wget http://download.owncloud.org/community/$TO
-  wget http://download.owncloud.org/community/testing/$TO
+  wget http://download.owncloud.org/community/$TO || true
+  wget http://download.owncloud.org/community/testing/$TO || true
 else
   echo "Reuse existing $TO"
 fi

--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -203,6 +203,8 @@ echo $GIT_BRANCH
 ./occ app:disable files_texteditor
 ./occ app:disable gallery
 ./occ app:disable files_videoplayer
+./occ app:disable files_videoviewer
+./occ app:disable updater
 
 if [ -v GIT_BRANCH ]; then
 	./occ app:disable configreport

--- a/update-testing/test-upgrade.sh
+++ b/update-testing/test-upgrade.sh
@@ -202,6 +202,7 @@ echo $GIT_BRANCH
 ./occ app:disable files_pdfviewer
 ./occ app:disable files_texteditor
 ./occ app:disable gallery
+./occ app:disable files_videoplayer
 
 if [ -v GIT_BRANCH ]; then
 	./occ app:disable configreport


### PR DESCRIPTION
## How to execute

```sh
$ ./test-upgrade.sh 9.1.4 git*master sqlite
```

This will upgrade from 9.1.4 to git master - as long as we have no tar balls including tests this is the only way I can think of.

## ToDo:
- [ ] *later* test mysql, pgsql and oci
- [ ] *not that later* switch to tar balls which include tests
- [ ] *now* test against a new branch in core where we upgrade from 9.0.0 to git*allow-major-upgrade