### PR TITLE
Push 10.0 instead of RC via beta channel. Closes #125

### DIFF
--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -200,7 +200,7 @@ return [
 		'9.1.5' => [
 			'latest' => '10.0.0',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
-			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.0.0RC1.zip',
+			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.0.0.zip',
 		],
 		'9.1' => [
 			'latest' => '9.1.5',

--- a/update-server/tests/integration/features/update.beta.feature
+++ b/update-server/tests/integration/features/update.beta.feature
@@ -14,7 +14,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "9.1.5"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.0RC1.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.0.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.1.0 on the beta channel


### PR DESCRIPTION
RC is outdated. 