### PR TITLE
[update-server] Allow 8.2 to 9.0 for production channel

### DIFF
--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -106,6 +106,10 @@ return [
 			'latest' => '8.2.11',
 			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
 		],
+		'8.2.11' => [
+			'latest' => '9.0.9',
+			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
+		],
 		'8.1' => [
 			'latest' => '8.1.12',
 			'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',

--- a/update-server/tests/integration/features/update.production.feature
+++ b/update-server/tests/integration/features/update.production.feature
@@ -76,7 +76,9 @@ Feature: Testing the update scenario of releases on the production channel
     Given There is a release with channel "production"
     And The received version is "8.2.11"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.9.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 8.2.0 on the production channel
     Given There is a release with channel "production"


### PR DESCRIPTION
Allow migration from 8.2.11 to 9.0 for `production` channel

Dedicated to a lovely memory of stable8.2 (EOL)

Tested by installing 8.2.11 and migrating to 9.0.9 afterwards. 
It is already possible with `stable` channel