### PR TITLE
Add 10.0.3rc1 to beta channel

### DIFF
--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -210,11 +210,13 @@ return [
 	],
 	'beta' => [
 		'10.0' => [
-			'latest' => '10.0.2',
+			'latest' => '10.0.3',
+			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.0.3beta.zip',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1.6' => [
-			'latest' => '10.0.2',
+			'latest' => '10.0.3',
+			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.0.3beta.zip',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1' => [

--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -211,12 +211,12 @@ return [
 	'beta' => [
 		'10.0' => [
 			'latest' => '10.0.3',
-			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.0.3beta.zip',
+			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.0.3RC1.zip',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1.6' => [
 			'latest' => '10.0.3',
-			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.0.3beta.zip',
+			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.0.3RC1.zip',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1' => [

--- a/update-server/tests/integration/features/update.beta.feature
+++ b/update-server/tests/integration/features/update.beta.feature
@@ -7,7 +7,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "10.0.2"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.3beta.zip"
+    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.3RC1.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 10.0.0 on the beta channel
@@ -15,7 +15,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "10.0.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.3beta.zip"
+    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.3RC1.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.1.x should go below #####
@@ -24,7 +24,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "9.1.6"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.3beta.zip"
+    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.3RC1.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.1.0 on the beta channel

--- a/update-server/tests/integration/features/update.beta.feature
+++ b/update-server/tests/integration/features/update.beta.feature
@@ -6,14 +6,16 @@ Feature: Testing the update scenario of releases on the beta channel
     Given There is a release with channel "beta"
     And The received version is "10.0.2"
     When The request is sent
-    Then The response is empty
-    
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.3beta.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
+
   Scenario: Updating an outdated ownCloud 10.0.0 on the beta channel
     Given There is a release with channel "beta"
     And The received version is "10.0.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.2.zip"
+    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.3beta.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.1.x should go below #####
@@ -22,7 +24,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "9.1.6"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.2.zip"
+    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.3beta.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.1.0 on the beta channel


### PR DESCRIPTION
Quick tests on beta channel:
- [x] update 10.0.2 -> 10.0.3rc1
- [x] update 9.1.6 -> 10.0.3rc1
- [x] ~~update 9.0.10 -> 10.0.3beta~~ 🚫 not possible, but we can make it possible for 9.0.11: https://github.com/owncloud/updater/issues/435
- [x] ~~update 8.2.11 -> 10.0.3beta~~ => not possible, updater app refuses to skip

@davitol @VicDeo 

@felixboehm FYI, at this point I'd like to make the web updater update directly to 10.0.3 when possible