### PR TITLE
Allow 10.0.x to 10.0.3 all channels, 9.1.6 to 10.0.3 at stable

### DIFF
--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -159,6 +159,11 @@ return [
 
 		// START: Due do a bug in the updater we need to enforce the update order
 		// see https://github.com/owncloud/administration-internal/issues/19
+		'9.0.10' => [
+			'latest' => '9.1.6',
+			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
+		],
+
 		'9.0' => [
 			'latest' => '9.0.10',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',

--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -80,7 +80,7 @@
 return [
 	'production' => [
 		'10.0' => [
-			'latest' => '10.0.2',
+			'latest' => '10.0.3',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1' => [
@@ -145,13 +145,18 @@ return [
 	],
 	'stable' => [
 		'10.0' => [
-			'latest' => '10.0.2',
+			'latest' => '10.0.3',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1' => [
 			'latest' => '9.1.6',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
+		'9.1.6' => [
+			'latest' => '10.0.3',
+			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
+		],
+
 		// START: Due do a bug in the updater we need to enforce the update order
 		// see https://github.com/owncloud/administration-internal/issues/19
 		'9.0' => [
@@ -211,12 +216,10 @@ return [
 	'beta' => [
 		'10.0' => [
 			'latest' => '10.0.3',
-			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.0.3RC1.zip',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1.6' => [
 			'latest' => '10.0.3',
-			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.0.3RC1.zip',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1' => [
@@ -290,11 +293,11 @@ return [
 		],
 		/* early 10.0 dailies had version 9.2.0.x */
 		'9.2' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.0.2.zip',
+			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.0.3.zip',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.0.2.zip',
+			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.0.3.zip',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.0' => [

--- a/update-server/tests/integration/features/update.beta.feature
+++ b/update-server/tests/integration/features/update.beta.feature
@@ -2,12 +2,12 @@ Feature: Testing the update scenario of releases on the beta channel
 ##### Please always order by version number descending #####
 
   ##### Tests for 10.0.x should go below #####
-  Scenario: Updating an outdated ownCloud 10.0.2 on the beta channel
+  Scenario: Updating an outdated ownCloud 10.0.3 on the beta channel
     Given There is a release with channel "beta"
     And The received version is "10.0.2"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.3RC1.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 10.0.0 on the beta channel
@@ -15,7 +15,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "10.0.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.3RC1.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.1.x should go below #####
@@ -24,7 +24,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "9.1.6"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.3RC1.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.1.0 on the beta channel

--- a/update-server/tests/integration/features/update.daily.feature
+++ b/update-server/tests/integration/features/update.daily.feature
@@ -28,7 +28,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.2.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.1.x should go below #####
@@ -39,7 +39,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.2.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated-dated ownCloud 9.1 daily
@@ -49,7 +49,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.2.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an up-to-date ownCloud 9.1 daily

--- a/update-server/tests/integration/features/update.production.feature
+++ b/update-server/tests/integration/features/update.production.feature
@@ -3,23 +3,31 @@ Feature: Testing the update scenario of releases on the production channel
 
 
   ##### Tests for 10.0.x should go below #####
-  Scenario: Updating an outdated ownCloud 10.0.2 on the beta channel
+  Scenario: Updating an outdated ownCloud 10.0.3 on the production channel
     Given There is a release with channel "production"
-    And The received version is "10.0.2"
+    And The received version is "10.0.3"
     When The request is sent
     Then The response is empty
+  
+  Scenario: Updating an outdated ownCloud 10.0.1 on the production channel
+    Given There is a release with channel "production"
+    And The received version is "10.0.1"
+    When The request is sent
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
     
-  Scenario: Updating an outdated ownCloud 10.0.0 on the beta channel
+  Scenario: Updating an outdated ownCloud 10.0.0 on the production channel
     Given There is a release with channel "production"
     And The received version is "10.0.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.2.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.1.x should go below #####
-  Scenario: Updating an outdated ownCloud 9.1.0 on the stable channel
-    Given There is a release with channel "stable"
+  Scenario: Updating an outdated ownCloud 9.1.0 on the production channel
+    Given There is a release with channel "production"
     And The received version is "9.1.6"
     When The request is sent
     Then The response is empty
@@ -33,8 +41,8 @@ Feature: Testing the update scenario of releases on the production channel
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.0.x should go below #####
-  Scenario: Updating an outdated ownCloud 9.0.10 on the stable channel
-    Given There is a release with channel "stable"
+  Scenario: Updating an outdated ownCloud 9.0.10 on the production channel
+    Given There is a release with channel "production"
     And The received version is "9.0.10"
     When The request is sent
     Then The response is empty

--- a/update-server/tests/integration/features/update.stable.feature
+++ b/update-server/tests/integration/features/update.stable.feature
@@ -46,8 +46,10 @@ Feature: Testing the update scenario of releases on the stable channel
     Given There is a release with channel "stable"
     And The received version is "9.0.10"
     When The request is sent
-    Then The response is empty
-  
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.6.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
+
   Scenario: Updating an outdated ownCloud 9.0.5 on the stable channel
     Given There is a release with channel "stable"
     And The received version is "9.0.5"

--- a/update-server/tests/integration/features/update.stable.feature
+++ b/update-server/tests/integration/features/update.stable.feature
@@ -2,26 +2,26 @@ Feature: Testing the update scenario of releases on the stable channel
 ##### Please always order by version number descending #####
 
   ##### Tests for 10.0.x should go below #####
-  Scenario: Updating an outdated ownCloud 10.0.2 on the beta channel
+  Scenario: Updating an outdated ownCloud 10.0.3 on the stable channel
     Given There is a release with channel "stable"
-    And The received version is "10.0.2"
+    And The received version is "10.0.3"
     When The request is sent
     Then The response is empty
     
-  Scenario: Updating an outdated ownCloud 10.0.1 on the beta channel
+  Scenario: Updating an outdated ownCloud 10.0.1 on the stable channel
     Given There is a release with channel "stable"
     And The received version is "10.0.1"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.2.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
     
-  Scenario: Updating an outdated ownCloud 10.0.0 on the beta channel
+  Scenario: Updating an outdated ownCloud 10.0.0 on the stable channel
     Given There is a release with channel "stable"
     And The received version is "10.0.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.2.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.1.x should go below #####
@@ -29,7 +29,9 @@ Feature: Testing the update scenario of releases on the stable channel
     Given There is a release with channel "stable"
     And The received version is "9.1.6"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
     
   Scenario: Updating an outdated ownCloud 9.1.0 on the stable channel
     Given There is a release with channel "stable"


### PR DESCRIPTION
- [x] 9.0.10 to 9.1.6 at `stable` channel
- [x] 9.1.6 to 10.0.3 at `stable` channel
- [x] 10.0.x to 10.0.3 for all channels except `daily` 
`daily` channel as usual allows 10.0.x  to master