### PR TITLE
Eol channel

### DIFF
--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -113,43 +113,6 @@ return [
 			'latest' => '9.0.4',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 		],
-		// END:  Due do a bug in the updater we need to enforce the update order
-		'8.2' => [
-			'latest' => '8.2.11',
-			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
-		],
-		'8.2.11' => [
-			'latest' => '9.0.11',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		'8.1' => [
-			'latest' => '8.1.12',
-			'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
-		],
-		'8.1.12' => [
-			'latest' => '8.2.11',
-			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
-		],
-		'8.0' => [
-			'latest' => '8.0.16',
-			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
-		],
-		'8.0.16' => [
-			'latest' => '8.1.12',
-			'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
-		],
-		'7' => [
-			'latest' => '7.0.15',
-			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
-		],
-		'7.0.15' => [
-			'latest' => '8.0.16',
-			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
-		],
-		'6' => [
-			'latest' => '7.0.15',
-			'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	'stable' => [
 		'10.0' => [
@@ -164,14 +127,12 @@ return [
 			'latest' => '10.0.8',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
-
 		// START: Due do a bug in the updater we need to enforce the update order
 		// see https://github.com/owncloud/administration-internal/issues/19
 		'9.0.11' => [
 			'latest' => '9.1.8',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
-
 		'9.0' => [
 			'latest' => '9.0.11',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
@@ -187,43 +148,6 @@ return [
 		'9.0.0' => [
 			'latest' => '9.0.4',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		// END:  Due do a bug in the updater we need to enforce the update order
-		'8.2' => [
-			'latest' => '8.2.11',
-			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
-		],
-		'8.2.11' => [
-			'latest' => '9.0.11',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		'8.1' => [
-			'latest' => '8.1.12',
-			'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
-		],
-		'8.1.12' => [
-			'latest' => '8.2.11',
-			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
-		],
-		'8.0' => [
-			'latest' => '8.0.16',
-			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
-		],
-		'8.0.16' => [
-			'latest' => '8.1.12',
-			'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
-		],
-		'7' => [
-			'latest' => '7.0.15',
-			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
-		],
-		'7.0.15' => [
-			'latest' => '8.0.16',
-			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
-		],
-		'6' => [
-			'latest' => '7.0.15',
-			'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
 		],
 	],
 	'beta' => [
@@ -262,43 +186,6 @@ return [
 			'latest' => '9.0.4',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 		],
-		// END:  Due do a bug in the updater we need to enforce the update order
-		'8.2' => [
-			'latest' => '8.2.11',
-			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
-		],
-		'8.2.11' => [
-			'latest' => '9.0.11',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		'8.1' => [
-			'latest' => '8.1.12',
-			'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
-		],
-		'8.1.12' => [
-			'latest' => '8.2.11',
-			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
-		],
-		'8.0' => [
-			'latest' => '8.0.16',
-			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
-		],
-		'8.0.16' => [
-			'latest' => '8.1.12',
-			'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
-		],
-		'7' => [
-			'latest' => '7.0.15',
-			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
-		],
-		'7.0.15' => [
-			'latest' => '8.0.16',
-			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
-		],
-		'6' => [
-			'latest' => '7.0.15',
-			'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	'daily' => [
 		'10.0' => [
@@ -318,26 +205,60 @@ return [
 			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-9.1.8.zip',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
-		'8.2' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-9.0.11.zip',
+	],
+	'eol' => [
+		'8.2.100' => [
+			'latest' => '9.0.11',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 		],
-		'8.1' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.2.11.zip',
+		'8.2.11' => [
+			'latest' => '9.0.10',
+			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
+		],
+		'8.2' => [
+			'latest' => '8.2.11',
 			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
 		],
-		'8.0' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.1.12.zip',
+		'8.1.100' => [
+			'latest' => '8.2.11',
+			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
+		],
+		'8.1.12' => [
+			'latest' => '8.2.11',
+			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
+		],
+		'8.1' => [
+			'latest' => '8.1.12',
 			'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
 		],
-		'7' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.0.16.zip',
+		'8.0.100' => [
+			'latest' => '8.1.12',
+			'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
+		],
+		'8.0.16' => [
+			'latest' => '8.1.12',
+			'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
+		],
+		'8.0' => [
+			'latest' => '8.0.16',
 			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 		],
-
+		'7.0.100' => [
+			'latest' => '8.0.16',
+			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
+		],
+		'7.0.15' => [
+			'latest' => '8.0.16',
+			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
+		],
+		'7' => [
+			'latest' => '7.0.15',
+			'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
+		],
 		'6' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-7.0.13.zip',
+			'latest' => '7.0.15',
 			'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
 		],
 	],
+	'eol_latest' => '8.2.100',
 ];

--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -91,28 +91,6 @@ return [
 			'latest' => '9.1.8',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
-		// START: Due do a bug in the updater we need to enforce the update order
-		// see https://github.com/owncloud/administration-internal/issues/19
-		'9.0.11' => [
-			'latest' => '9.1.8',
-			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
-		],
-		'9.0' => [
-			'latest' => '9.0.11',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		'9.0.2' => [
-			'latest' => '9.0.4',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		'9.0.1' => [
-			'latest' => '9.0.4',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		'9.0.0' => [
-			'latest' => '9.0.4',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	'stable' => [
 		'10.0' => [
@@ -126,28 +104,6 @@ return [
 		'9.1.8' => [
 			'latest' => '10.0.8',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
-		],
-		// START: Due do a bug in the updater we need to enforce the update order
-		// see https://github.com/owncloud/administration-internal/issues/19
-		'9.0.11' => [
-			'latest' => '9.1.8',
-			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
-		],
-		'9.0' => [
-			'latest' => '9.0.11',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		'9.0.2' => [
-			'latest' => '9.0.4',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		'9.0.1' => [
-			'latest' => '9.0.4',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		'9.0.0' => [
-			'latest' => '9.0.4',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 		],
 	],
 	'beta' => [
@@ -164,28 +120,6 @@ return [
 			'latest' => '9.1.8',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
-		// START: Due do a bug in the updater we need to enforce the update order
-		// see https://github.com/owncloud/administration-internal/issues/19
-		'9.0' => [
-			'latest' => '9.0.11',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		'9.0.11' => [
-			'latest' => '9.1.8',
-			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
-		],
-		'9.0.2' => [
-			'latest' => '9.0.4',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		'9.0.1' => [
-			'latest' => '9.0.4',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
-		'9.0.0' => [
-			'latest' => '9.0.4',
-			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	'daily' => [
 		'10.0' => [
@@ -201,18 +135,41 @@ return [
 			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.0.8.zip',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
-		'9.0' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-9.1.8.zip',
-			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	'eol' => [
+		'9.0.100' => [
+			'latest' => '9.1.8',
+			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
+		],
+		// START: Due do a bug in the updater we need to enforce the update order
+		// see https://github.com/owncloud/administration-internal/issues/19
+		'9.0.11' => [
+			'latest' => '9.1.8',
+			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
+		],
+		'9.0' => [
+			'latest' => '9.0.11',
+			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
+		],
+		'9.0.2' => [
+			'latest' => '9.0.4',
+			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
+		],
+		'9.0.1' => [
+			'latest' => '9.0.4',
+			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
+		],
+		'9.0.0' => [
+			'latest' => '9.0.4',
+			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
+		],
+		// END:  Due do a bug in the updater we need to enforce the update order
 		'8.2.100' => [
 			'latest' => '9.0.11',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 		],
 		'8.2.11' => [
-			'latest' => '9.0.10',
+			'latest' => '9.0.11',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 		],
 		'8.2' => [
@@ -260,5 +217,5 @@ return [
 			'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
 		],
 	],
-	'eol_latest' => '8.2.100',
+	'eol_latest' => '9.0.100',
 ];

--- a/update-server/src/Response.php
+++ b/update-server/src/Response.php
@@ -55,7 +55,10 @@ class Response {
 	 * @return string
 	 */
 	private function getDownloadUrl($newVersion){
-		$downloadUrl = 'https://download.owncloud.org/community/owncloud-'.$newVersion['latest'].'.zip';
+		$downloadUrl = '';
+		if (isset($newVersion['latest'])) {
+			$downloadUrl = 'https://download.owncloud.org/community/owncloud-' . $newVersion['latest'] . '.zip';
+		}
 		if (isset($newVersion['downloadUrl'])) {
 			$downloadUrl = $newVersion['downloadUrl'];
 		}

--- a/update-server/tests/integration/features/update.daily.feature
+++ b/update-server/tests/integration/features/update.daily.feature
@@ -207,7 +207,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-7.0.13.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-7.0.15.zip"
     And URL to documentation is "https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated-dated ownCloud 6 daily
@@ -217,7 +217,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-7.0.13.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-7.0.15.zip"
     And URL to documentation is "https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an up-to-date ownCloud 6 daily

--- a/update-server/tests/integration/features/update.stable.feature
+++ b/update-server/tests/integration/features/update.stable.feature
@@ -99,12 +99,6 @@ Feature: Testing the update scenario of releases on the stable channel
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 8.2.x should go below #####
-  Scenario: Updating an up-to-date ownCloud 8.2.100
-    Given There is a release with channel "stable"
-    And The received version is "8.2.100"
-    When The request is sent
-    Then The response is empty
-
   Scenario: Updating an outdated ownCloud 8.2.11 on the stable channel
     Given There is a release with channel "stable"
     And The received version is "8.2.11"

--- a/update-server/tests/unit/ResponseTest.php
+++ b/update-server/tests/unit/ResponseTest.php
@@ -121,42 +121,42 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			->expects($this->any())
 			->method('getBuild')
 			->willReturn('2015-10-19T18:44:30+00:00');
+		$map = [
+			['eol_latest', '4.0'],
+			['daily', [
+				'9.1' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-master.zip',
+					'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
+				],
+				'9.0' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-master.zip',
+					'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
+				],
+				'8.2' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-stable9.zip',
+					'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
+				],
+				'8.1' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.2.3.zip',
+					'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
+				],
+				'8.0' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.1.6.zip',
+					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
+				],
+				'7' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.0.11.zip',
+					'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
+				],
+				'6' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-7.0.13.zip',
+					'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
+				],
+			]]
+		];
 		$this->config
-			->expects($this->once())
 			->method('get')
-			->with('daily')
-			->willReturn(
-				[
-					'9.1' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-master.zip',
-						'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
-					],
-					'9.0' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-master.zip',
-						'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-					],
-					'8.2' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-stable9.zip',
-						'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
-					],
-					'8.1' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.2.3.zip',
-						'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
-					],
-					'8.0' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.1.6.zip',
-						'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
-					],
-					'7' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.0.11.zip',
-						'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
-					],
-					'6' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-7.0.13.zip',
-						'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
-					],
-				]
-			);
+			->will($this->returnValueMap($map));
 		$this->request
 			->expects($this->any())
 			->method('getMajorVersion')
@@ -193,43 +193,43 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				->method('getMinorVersion')
 				->willReturn($version[4]);
 		}
+		$map = [
+			['eol_latest', '4.0'],
+			['daily', [
+				'9.1' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-master.zip',
+					'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
+				],
+				'9.0' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-master.zip',
+					'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
+				],
+				'8.2' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-stable9.zip',
+					'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
+				],
+				'8.1' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.2.3.zip',
+					'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
+				],
+				'8.0' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.1.6.zip',
+					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
+				],
+				'7' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.0.11.zip',
+					'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
+				],
+				'6' => [
+					'downloadUrl' => 'https://download.owncloud.org/community/owncloud-7.0.13.zip',
+					'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
+				],
+			]
+			]
+		];
 		$this->config
-			->expects($this->once())
 			->method('get')
-			->with('daily')
-			->willReturn(
-				[
-					'9.1' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-master.zip',
-						'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
-					],
-					'9.0' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-master.zip',
-						'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
-					],
-					'8.2' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-stable9.zip',
-						'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
-					],
-					'8.1' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.2.3.zip',
-						'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
-					],
-					'8.0' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.1.6.zip',
-						'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
-					],
-					'7' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-8.0.11.zip',
-						'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
-					],
-					'6' => [
-						'downloadUrl' => 'https://download.owncloud.org/community/owncloud-7.0.13.zip',
-						'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
-					],
-				]
-			);
-
+			->will($this->returnValueMap($map));
 		$expected = '';
 
 		$this->assertSame($expected, $this->response->buildResponse());
@@ -702,15 +702,19 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'downloadUrl' => 'https://downloads.owncloud.com/foo.zip',
 			],
 		];
+		$map = [
+			['eol_latest', '1'],
+			[$channel, $config],
+			['eol',  $config ],
+		];
+
 		$this->request
 			->expects($this->any())
 			->method('getChannel')
 			->willReturn($channel);
 		$this->config
-			->expects($this->any())
 			->method('get')
-			->with($channel)
-			->willReturn($config);
+			->will($this->returnValueMap($map));
 		$this->request
 			->expects($this->any())
 			->method('getMajorVersion')


### PR DESCRIPTION
This PR adds a virtual `eol` channel that is common for all channels
The `eol` channel holds the releases that reached EOL.

Motivation: I'm tired from scrolling down from one channel to another and the distance is increasing with major releases.

Fixing two minor issues:
- `daily` channel was referring to 7.0.13 as the latest 7.0.x release (it should be 7.0.15)
-  test for the `stable` channel held a version `8.2.100` that is legit for `daily` channel only

It also eliminates  discrepancies between `daily` and other channels:
before this PR  all channels  were using `downloadUrl` array key  as an override for the `latest` array key
while `daily` used `downloadUrl` only.
Now all channel incl `daily` are using `downloadUrl` array key  as an override for the `latest` array key.

@PVince81 please save my mousewheel by reviewing this PR.