### PR TITLE
Release 9.0.11, 9.1.7, 10.0.4

### DIFF
--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -80,21 +80,21 @@
 return [
 	'production' => [
 		'10.0' => [
-			'latest' => '10.0.3',
+			'latest' => '10.0.4',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1' => [
-			'latest' => '9.1.6',
+			'latest' => '9.1.7',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
 		// START: Due do a bug in the updater we need to enforce the update order
 		// see https://github.com/owncloud/administration-internal/issues/19
-		'9.0.10' => [
-			'latest' => '9.1.6',
+		'9.0.11' => [
+			'latest' => '9.1.7',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
 		'9.0' => [
-			'latest' => '9.0.10',
+			'latest' => '9.0.11',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.0.2' => [
@@ -115,7 +115,7 @@ return [
 			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
 		],
 		'8.2.11' => [
-			'latest' => '9.0.10',
+			'latest' => '9.0.11',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 		],
 		'8.1' => [
@@ -149,27 +149,27 @@ return [
 	],
 	'stable' => [
 		'10.0' => [
-			'latest' => '10.0.3',
+			'latest' => '10.0.4',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1' => [
-			'latest' => '9.1.6',
+			'latest' => '9.1.7',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
-		'9.1.6' => [
-			'latest' => '10.0.3',
+		'9.1.7' => [
+			'latest' => '10.0.4',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
 
 		// START: Due do a bug in the updater we need to enforce the update order
 		// see https://github.com/owncloud/administration-internal/issues/19
-		'9.0.10' => [
-			'latest' => '9.1.6',
+		'9.0.11' => [
+			'latest' => '9.1.7',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
 
 		'9.0' => [
-			'latest' => '9.0.10',
+			'latest' => '9.0.11',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.0.2' => [
@@ -190,7 +190,7 @@ return [
 			'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
 		],
 		'8.2.11' => [
-			'latest' => '9.0.10',
+			'latest' => '9.0.11',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 		],
 		'8.1' => [
@@ -225,12 +225,10 @@ return [
 	'beta' => [
 		'10.0' => [
 			'latest' => '10.0.4',
-			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.0.4RC1.zip',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1.7' => [
 			'latest' => '10.0.4',
-			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.0.4RC1.zip',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1' => [
@@ -305,19 +303,19 @@ return [
 		],
 		/* early 10.0 dailies had version 9.2.0.x */
 		'9.2' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.0.3.zip',
+			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.0.4.zip',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.0.3.zip',
+			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.0.4.zip',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.0' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-9.1.6.zip',
+			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-9.1.7.zip',
 			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
 		'8.2' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-9.0.10.zip',
+			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-9.0.11.zip',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 		],
 		'8.1' => [

--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -89,6 +89,10 @@ return [
 		],
 		// START: Due do a bug in the updater we need to enforce the update order
 		// see https://github.com/owncloud/administration-internal/issues/19
+		'9.0.10' => [
+			'latest' => '9.1.6',
+			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
+		],
 		'9.0' => [
 			'latest' => '9.0.10',
 			'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',

--- a/update-server/tests/integration/features/update.beta.feature
+++ b/update-server/tests/integration/features/update.beta.feature
@@ -13,7 +13,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "10.0.3"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.4RC1.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.4.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 10.0.0 on the beta channel
@@ -21,7 +21,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "10.0.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.4RC1.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.4.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.1.x should go below #####
@@ -30,7 +30,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "9.1.7"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.0.4RC1.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.4.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.1.0 on the beta channel

--- a/update-server/tests/integration/features/update.daily.feature
+++ b/update-server/tests/integration/features/update.daily.feature
@@ -28,7 +28,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.4.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.1.x should go below #####
@@ -39,7 +39,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.4.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated-dated ownCloud 9.1 daily
@@ -49,7 +49,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.4.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an up-to-date ownCloud 9.1 daily
@@ -67,7 +67,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.6.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.7.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated-dated ownCloud 9.0 daily
@@ -77,7 +77,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.6.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.7.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an up-to-date ownCloud 9.0 daily
@@ -95,7 +95,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.10.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.11.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated-dated ownCloud 8.2 daily
@@ -105,7 +105,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.10.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.11.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an up-to-date ownCloud 8.2 daily

--- a/update-server/tests/integration/features/update.production.feature
+++ b/update-server/tests/integration/features/update.production.feature
@@ -3,9 +3,9 @@ Feature: Testing the update scenario of releases on the production channel
 
 
   ##### Tests for 10.0.x should go below #####
-  Scenario: Updating an outdated ownCloud 10.0.3 on the production channel
+  Scenario: Updating an outdated ownCloud 10.0.4 on the production channel
     Given There is a release with channel "production"
-    And The received version is "10.0.3"
+    And The received version is "10.0.4"
     When The request is sent
     Then The response is empty
   
@@ -14,7 +14,7 @@ Feature: Testing the update scenario of releases on the production channel
     And The received version is "10.0.1"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.4.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
     
   Scenario: Updating an outdated ownCloud 10.0.0 on the production channel
@@ -22,13 +22,13 @@ Feature: Testing the update scenario of releases on the production channel
     And The received version is "10.0.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.4.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.1.x should go below #####
   Scenario: Updating an outdated ownCloud 9.1.0 on the production channel
     Given There is a release with channel "production"
-    And The received version is "9.1.6"
+    And The received version is "9.1.7"
     When The request is sent
     Then The response is empty
   
@@ -37,16 +37,16 @@ Feature: Testing the update scenario of releases on the production channel
     And The received version is "9.1.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.6.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.7.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.0.x should go below #####
-  Scenario: Updating an outdated ownCloud 9.0.10 on the production channel
+  Scenario: Updating an outdated ownCloud 9.0.11 on the production channel
     Given There is a release with channel "production"
-    And The received version is "9.0.10"
+    And The received version is "9.0.11"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.6.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.7.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
   
   Scenario: Updating an outdated ownCloud 9.0.5 on the production channel
@@ -54,7 +54,7 @@ Feature: Testing the update scenario of releases on the production channel
     And The received version is "9.0.5"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.10.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.11.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.0.4 on the production channel
@@ -62,7 +62,7 @@ Feature: Testing the update scenario of releases on the production channel
     And The received version is "9.0.4"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.10.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.11.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.0.3 on the production channel
@@ -70,7 +70,7 @@ Feature: Testing the update scenario of releases on the production channel
     And The received version is "9.0.3"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.10.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.11.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.0.2 on the production channel
@@ -103,7 +103,7 @@ Feature: Testing the update scenario of releases on the production channel
     And The received version is "8.2.11"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.10.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.11.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 8.2.0 on the production channel

--- a/update-server/tests/integration/features/update.production.feature
+++ b/update-server/tests/integration/features/update.production.feature
@@ -45,7 +45,9 @@ Feature: Testing the update scenario of releases on the production channel
     Given There is a release with channel "production"
     And The received version is "9.0.10"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.6.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
   
   Scenario: Updating an outdated ownCloud 9.0.5 on the production channel
     Given There is a release with channel "production"

--- a/update-server/tests/integration/features/update.stable.feature
+++ b/update-server/tests/integration/features/update.stable.feature
@@ -2,9 +2,9 @@ Feature: Testing the update scenario of releases on the stable channel
 ##### Please always order by version number descending #####
 
   ##### Tests for 10.0.x should go below #####
-  Scenario: Updating an outdated ownCloud 10.0.3 on the stable channel
+  Scenario: Updating an outdated ownCloud 10.0.4 on the stable channel
     Given There is a release with channel "stable"
-    And The received version is "10.0.3"
+    And The received version is "10.0.4"
     When The request is sent
     Then The response is empty
     
@@ -13,7 +13,7 @@ Feature: Testing the update scenario of releases on the stable channel
     And The received version is "10.0.1"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.4.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
     
   Scenario: Updating an outdated ownCloud 10.0.0 on the stable channel
@@ -21,16 +21,16 @@ Feature: Testing the update scenario of releases on the stable channel
     And The received version is "10.0.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.4.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.1.x should go below #####
   Scenario: Updating an outdated ownCloud 9.1.0 on the stable channel
     Given There is a release with channel "stable"
-    And The received version is "9.1.6"
+    And The received version is "9.1.7"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.3.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.4.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
     
   Scenario: Updating an outdated ownCloud 9.1.0 on the stable channel
@@ -38,16 +38,16 @@ Feature: Testing the update scenario of releases on the stable channel
     And The received version is "9.1.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.6.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.7.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.0.x should go below #####
-  Scenario: Updating an outdated ownCloud 9.0.10 on the stable channel
+  Scenario: Updating an outdated ownCloud 9.0.11 on the stable channel
     Given There is a release with channel "stable"
-    And The received version is "9.0.10"
+    And The received version is "9.0.11"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.6.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.7.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.0.5 on the stable channel
@@ -55,7 +55,7 @@ Feature: Testing the update scenario of releases on the stable channel
     And The received version is "9.0.5"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.10.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.11.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.0.4 on the stable channel
@@ -63,7 +63,7 @@ Feature: Testing the update scenario of releases on the stable channel
     And The received version is "9.0.4"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.10.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.11.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.0.3 on the stable channel
@@ -71,7 +71,7 @@ Feature: Testing the update scenario of releases on the stable channel
     And The received version is "9.0.3"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.10.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.11.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.0.2 on the stable channel
@@ -110,7 +110,7 @@ Feature: Testing the update scenario of releases on the stable channel
     And The received version is "8.2.11"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.10.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.11.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 8.2.0 on the stable channel


### PR DESCRIPTION
Allows
- [x] 8.2.11 -> 9.0.11 (all channels)
- [x] 9.0.11 -> 9.1.7 (all channels)
- [x] 9.1.7 -> 10.0.4 (all channels)

Given that 9.0 is close to EOL I suggest to align production and stable channels.
All other channels already offer this transition so I don't think that much testing is needed here.
Closes https://github.com/owncloud/updater/issues/431