### PR TITLE
Release 10.2 on beta and daily channels

### DIFF
--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -108,13 +108,17 @@ return [
 		],
 	],
 	'beta' => [
+		'10.1' => [
+			'latest' => '10.2.0',
+			'web' => 'https://doc.owncloud.org/server/10.1/admin_manual/maintenance/upgrade.html',
+		],
 		'10.0' => [
-			'latest' => '10.0.10',
+			'latest' => '10.2.0',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1.8' => [
-			'latest' => '10.0.10',
-			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
+			'latest' => '10.2.0',
+			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1' => [
 			'latest' => '9.1.8',
@@ -122,18 +126,26 @@ return [
 		],
 	],
 	'daily' => [
+		'10.2' => [
+			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-stable10.zip',
+			'web' => 'https://doc.owncloud.org/server/10.2/admin_manual/maintenance/upgrade.html',
+		],
+		'10.1' => [
+			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.2.0.zip',
+			'web' => 'https://doc.owncloud.org/server/10.1/admin_manual/maintenance/upgrade.html',
+		],
 		'10.0' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-master.zip',
+			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.2.0.zip',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		/* early 10.0 dailies had version 9.2.0.x */
 		'9.2' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.0.10.zip',
+			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.2.0.zip',
 			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
 		],
 		'9.1' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.0.10.zip',
-			'web' => 'https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html',
+			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-10.2.0.zip',
+			'web' => 'https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html',
 		],
 	],
 	'eol' => [

--- a/update-server/tests/integration/features/update.beta.feature
+++ b/update-server/tests/integration/features/update.beta.feature
@@ -1,19 +1,45 @@
 Feature: Testing the update scenario of releases on the beta channel
 ##### Please always order by version number descending #####
 
+  ##### Tests for 10.2.x should go below #####
+  Scenario: Updating an outdated ownCloud 10.2.0 on the beta channel
+    Given There is a release with channel "beta"
+    And The received version is "10.2.0"
+    When The request is sent
+    Then The response is empty
+
+  ##### Tests for 10.1.x should go below #####
+  Scenario: Updating an outdated ownCloud 10.1.0 on the beta channel
+    Given There is a release with channel "beta"
+    And The received version is "10.1.0"
+    When The request is sent
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.2.0.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/10.1/admin_manual/maintenance/upgrade.html"
+    
+  Scenario: Updating an outdated ownCloud 10.1.1 on the beta channel
+    Given There is a release with channel "beta"
+    And The received version is "10.1.1"
+    When The request is sent
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.2.0.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/10.1/admin_manual/maintenance/upgrade.html"
+
   ##### Tests for 10.0.x should go below #####
   Scenario: Updating an outdated ownCloud 10.0.10 on the beta channel
     Given There is a release with channel "beta"
     And The received version is "10.0.10"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.2.0.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 10.0.0 on the beta channel
     Given There is a release with channel "beta"
     And The received version is "10.0.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.10.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.2.0.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.1.x should go below #####
@@ -22,8 +48,8 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "9.1.8"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.10.zip"
-    And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.2.0.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
   Scenario: Updating an outdated ownCloud 9.1.0 on the beta channel
     Given There is a release with channel "beta"

--- a/update-server/tests/integration/features/update.daily.feature
+++ b/update-server/tests/integration/features/update.daily.feature
@@ -1,7 +1,43 @@
 Feature: Testing the update scenario of releases on the daily channel
 ##### Please always order by version number descending #####
 
-  ##### Tests 10.0 should go below #####
+  ##### Tests for 10.2 should go below #####
+  Scenario: Updating an outdated-dated ownCloud 10.2 daily
+    Given There is a release with channel "daily"
+    And The received version is "10.2.100"
+    And the received build is "2018-10-19T18:44:30+00:00"
+    When The request is sent
+    Then The response is non-empty
+    And Update to version "100.0.0.0" is available
+    And URL to download is "https://download.owncloud.org/community/owncloud-daily-stable10.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/10.2/admin_manual/maintenance/upgrade.html"
+    
+  Scenario: Updating an up-to-date ownCloud 10.2 daily
+    Given There is a release with channel "daily"
+    And The received version is "10.2.100"
+    And the received build is "2021-10-19T18:44:30+00:00"
+    When The request is sent
+    Then The response is empty
+
+  ##### Tests for 10.1 should go below #####
+  Scenario: Updating an outdated-dated ownCloud 10.1 daily
+    Given There is a release with channel "daily"
+    And The received version is "10.1.100"
+    And the received build is "2018-10-19T18:44:30+00:00"
+    When The request is sent
+    Then The response is non-empty
+    And Update to version "100.0.0.0" is available
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.2.0.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/10.1/admin_manual/maintenance/upgrade.html"
+    
+  Scenario: Updating an up-to-date ownCloud 10.1 daily
+    Given There is a release with channel "daily"
+    And The received version is "10.1.100"
+    And the received build is "2021-10-19T18:44:30+00:00"
+    When The request is sent
+    Then The response is empty
+
+  ##### Tests for 10.0 should go below #####
   Scenario: Updating an outdated-dated ownCloud 10.0 daily
     Given There is a release with channel "daily"
     And The received version is "10.0.100"
@@ -9,17 +45,15 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-daily-master.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.2.0.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
-    
+
+  Scenario: Updating an up-to-date ownCloud 10.0 daily
     Given There is a release with channel "daily"
     And The received version is "10.0.100"
-    And the received build is "2015-10-19T18:44:30+00:00"
+    And the received build is "2021-10-19T18:44:30+00:00"
     When The request is sent
-    Then The response is non-empty
-    And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-daily-master.zip"
-    And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
+    Then The response is empty
 
   ##### Tests for 9.2.x (changed to 10.0) should go below #####
     Given There is a release with channel "daily"
@@ -28,7 +62,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.10.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.2.0.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.1.x should go below #####
@@ -39,25 +73,8 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.10.zip"
-    And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
-
-  Scenario: Updating an outdated-dated ownCloud 9.1 daily
-    Given There is a release with channel "daily"
-    And The received version is "9.1.100"
-    And the received build is "2012-10-19T18:44:30+00:00%208ee2009de36e01a9866404f07722892f84c16e3e"
-    When The request is sent
-    Then The response is non-empty
-    And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.0.10.zip"
-    And URL to documentation is "https://doc.owncloud.org/server/10.0/admin_manual/maintenance/upgrade.html"
-
-  Scenario: Updating an up-to-date ownCloud 9.1 daily
-    Given There is a release with channel "daily"
-    And The received version is "9.1.100"
-    And the received build is "2019-10-19T18:44:30+00:00"
-    When The request is sent
-    Then The response is empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.2.0.zip"
+    And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
   ##### Tests for 9.0.x should go below #####
   Scenario: Updating an outdated-dated ownCloud 9.0 daily
@@ -70,23 +87,6 @@ Feature: Testing the update scenario of releases on the daily channel
     And URL to download is "https://download.owncloud.org/community/owncloud-9.1.8.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
 
-  Scenario: Updating an outdated-dated ownCloud 9.0 daily
-    Given There is a release with channel "daily"
-    And The received version is "9.0.100"
-    And the received build is "2012-10-19T18:44:30+00:00%208ee2009de36e01a9866404f07722892f84c16e3e"
-    When The request is sent
-    Then The response is non-empty
-    And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.1.8.zip"
-    And URL to documentation is "https://doc.owncloud.org/server/9.1/admin_manual/maintenance/upgrade.html"
-
-  Scenario: Updating an up-to-date ownCloud 9.0 daily
-    Given There is a release with channel "daily"
-    And The received version is "9.0.100"
-    And the received build is "2019-10-19T18:44:30+00:00"
-    When The request is sent
-    Then The response is empty
-
   ##### Tests for 8.2.x should go below #####
   Scenario: Updating an outdated-dated ownCloud 8.2 daily
     Given There is a release with channel "daily"
@@ -97,23 +97,6 @@ Feature: Testing the update scenario of releases on the daily channel
     And Update to version "100.0.0.0" is available
     And URL to download is "https://download.owncloud.org/community/owncloud-9.0.11.zip"
     And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
-
-  Scenario: Updating an outdated-dated ownCloud 8.2 daily
-    Given There is a release with channel "daily"
-    And The received version is "8.2.100"
-    And the received build is "2012-10-19T18:44:30+00:00%208ee2009de36e01a9866404f07722892f84c16e3e"
-    When The request is sent
-    Then The response is non-empty
-    And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-9.0.11.zip"
-    And URL to documentation is "https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html"
-
-  Scenario: Updating an up-to-date ownCloud 8.2 daily
-    Given There is a release with channel "daily"
-    And The received version is "8.2.100"
-    And the received build is "2019-10-19T18:44:30+00:00"
-    When The request is sent
-    Then The response is empty
 
   ##### Tests for 8.1.x should go below #####
   Scenario: Updating an outdated-dated ownCloud 8.1 daily
@@ -126,23 +109,6 @@ Feature: Testing the update scenario of releases on the daily channel
     And URL to download is "https://download.owncloud.org/community/owncloud-8.2.11.zip"
     And URL to documentation is "https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html"
 
-  Scenario: Updating an outdated-dated ownCloud 8.1 daily
-    Given There is a release with channel "daily"
-    And The received version is "8.1.100"
-    And the received build is "2012-10-19T18:44:30+00:00%208ee2009de36e01a9866404f07722892f84c16e3e"
-    When The request is sent
-    Then The response is non-empty
-    And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-8.2.11.zip"
-    And URL to documentation is "https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html"
-
-  Scenario: Updating an up-to-date ownCloud 8.1 daily
-    Given There is a release with channel "daily"
-    And The received version is "8.1.100"
-    And the received build is "2019-10-19T18:44:30+00:00"
-    When The request is sent
-    Then The response is empty
-
   ##### Tests for 8.0.x should go below #####
   Scenario: Updating an outdated-dated ownCloud 8 daily
     Given There is a release with channel "daily"
@@ -153,23 +119,6 @@ Feature: Testing the update scenario of releases on the daily channel
     And Update to version "100.0.0.0" is available
     And URL to download is "https://download.owncloud.org/community/owncloud-8.1.12.zip"
     And URL to documentation is "https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html"
-
-  Scenario: Updating an outdated-dated ownCloud 8 daily
-    Given There is a release with channel "daily"
-    And The received version is "8.0.100"
-    And the received build is "2012-10-19T18:44:30+00:00%208ee2009de36e01a9866404f07722892f84c16e3e"
-    When The request is sent
-    Then The response is non-empty
-    And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-8.1.12.zip"
-    And URL to documentation is "https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html"
-
-  Scenario: Updating an up-to-date ownCloud 8 daily
-    Given There is a release with channel "daily"
-    And The received version is "8.0.100"
-    And the received build is "2019-10-19T18:44:30+00:00"
-    When The request is sent
-    Then The response is empty
 
   ##### Tests for 7.0.x should go below #####
   Scenario: Updating an outdated-dated ownCloud 7 daily
@@ -182,23 +131,6 @@ Feature: Testing the update scenario of releases on the daily channel
     And URL to download is "https://download.owncloud.org/community/owncloud-8.0.16.zip"
     And URL to documentation is "https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html"
 
-  Scenario: Updating an outdated-dated ownCloud 7 daily
-    Given There is a release with channel "daily"
-    And The received version is "7.0.100"
-    And the received build is "2012-10-19T18:44:30+00:00%208ee2009de36e01a9866404f07722892f84c16e3e"
-    When The request is sent
-    Then The response is non-empty
-    And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-8.0.16.zip"
-    And URL to documentation is "https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html"
-
-  Scenario: Updating an up-to-date ownCloud 7 daily
-    Given There is a release with channel "daily"
-    And The received version is "7.0.100"
-    And the received build is "2019-10-19T18:44:30+00:00"
-    When The request is sent
-    Then The response is empty
-
   ##### Tests for 6.0.x should go below #####
   Scenario: Updating an outdated-dated ownCloud 6 daily
     Given There is a release with channel "daily"
@@ -209,20 +141,3 @@ Feature: Testing the update scenario of releases on the daily channel
     And Update to version "100.0.0.0" is available
     And URL to download is "https://download.owncloud.org/community/owncloud-7.0.15.zip"
     And URL to documentation is "https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html"
-
-  Scenario: Updating an outdated-dated ownCloud 6 daily
-    Given There is a release with channel "daily"
-    And The received version is "6.0.100"
-    And the received build is "2012-10-19T18:44:30+00:00%208ee2009de36e01a9866404f07722892f84c16e3e"
-    When The request is sent
-    Then The response is non-empty
-    And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-7.0.15.zip"
-    And URL to documentation is "https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html"
-
-  Scenario: Updating an up-to-date ownCloud 6 daily
-    Given There is a release with channel "daily"
-    And The received version is "6.0.100"
-    And the received build is "2019-10-19T18:44:30+00:00"
-    When The request is sent
-    Then The response is empty


### PR DESCRIPTION
Unlock 10.2 on beta and daily channels.
Remove duplicated and irrelevant test cases for the daily channel