### PR TITLE
Push 10.5.0 beta to the beta channel

### DIFF
--- a/update-server/config/config.php
+++ b/update-server/config/config.php
@@ -91,6 +91,11 @@ return [
 		],
 	],
 	'beta' => [
+		'10.4.1' => [
+			'latest' => '10.5.0',
+			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.5.0beta1.zip',
+			'web' => 'https://doc.owncloud.org/server/10.4/admin_manual/maintenance/upgrade.html',
+		],
 		'10.4.0' => [
 			'latest' => '10.4.1',
 			'web' => 'https://doc.owncloud.org/server/10.4/admin_manual/maintenance/upgrade.html',

--- a/update-server/tests/integration/features/update.beta.feature
+++ b/update-server/tests/integration/features/update.beta.feature
@@ -1,12 +1,20 @@
 Feature: Testing the update scenario of releases on the beta channel
 ##### Please always order by version number descending #####
 
+  ##### Tests for 10.5.0 should go below #####
+  Scenario: Updating an ownCloud 10.5.0 on the beta channel
+    Given There is a release with channel "beta"
+    And The received version is "10.5.0"
+    When The request is sent
+    Then The response is empty
+
   ##### Tests for 10.4.x should go below #####
   Scenario: Updating an ownCloud 10.4.1 on the beta channel
     Given There is a release with channel "beta"
     And The received version is "10.4.1"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.5.0beta1.zip"
   
   Scenario: Updating an ownCloud 10.4.0 on the beta channel
     Given There is a release with channel "beta"


### PR DESCRIPTION
- [x]: validate that ~`https://download.owncloud.org/community/testing/owncloud-10.5.0beta.zip` is downloadable~ 
Url has been changed to https://download.owncloud.org/community/testing/owncloud-10.5.0beta1.zip
